### PR TITLE
Pass exception from previous loop to block.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ array.each.retry(Exception, SignalException) { |i| i.call }
   # => 1
 ```
 
+For the sake of reporting, previous exceptions are passed to the block.
+
+```ruby
+[0, 1].each.retry do |i, ex|
+  puts "LOG: Retrying due to exception: #{ex.to_s}" unless ex.nil?
+  raise "bar"
+end
+  # => LOG: Retrying due to exception: bar
+  # => RuntimeError: bar
+```
+
 ## Is it Complex?
 
 Naw, it's 8 lines of ruby:

--- a/lib/rrrretry.rb
+++ b/lib/rrrretry.rb
@@ -38,7 +38,7 @@ module Enumerable
       end
 
       begin
-        return yield value
+        return yield value, last_exception
       rescue *exceptions => e
         last_exception = e
       end

--- a/test/rrrretry_test.rb
+++ b/test/rrrretry_test.rb
@@ -44,4 +44,14 @@ class Rrrrretry_test < Test::Unit::TestCase
       end
     end
   end
+
+  def test_passes_previous_exception
+    exceptions = []
+    3.times.retry do |en,ex|
+      exceptions << (ex.nil? ? 'nil' : ex.message)
+      1/en
+    end
+
+    assert_equal(['nil', 'divided by 0'], exceptions)
+  end
 end


### PR DESCRIPTION
This is to allow reporting of errors so they can be addressed while still retrying the block.
